### PR TITLE
style: fix hero section after crt tv effects

### DIFF
--- a/src/components/home/Hero.astro
+++ b/src/components/home/Hero.astro
@@ -93,7 +93,7 @@ const { class: className, ...rest } = Astro.props;
     .terminal-prompt,
     .title {
         position: relative;
-        width: fit-content;
+        max-width: fit-content;
         /* Phosphor glow + Chromatic aberration */
         text-shadow:
             0 0 1px currentColor,


### PR DESCRIPTION
We need to use `max-width`. With `width` the ASCII art doesn't scroll on the mobile layout but instead extends the content.