### PR TITLE
style: improve title of Postcard for mobile layouts

### DIFF
--- a/src/components/blog/PostCard.astro
+++ b/src/components/blog/PostCard.astro
@@ -94,8 +94,7 @@ const categoryData = getCategoryData(post.frontmatter.category);
         border: 1px solid var(--color-text);
         border-radius: 0.5rem;
         padding: 1.5rem;
-        padding-block-start: 2rem;
-        margin-block-start: 3rem;
+        margin-block-start: 2rem;
         text-decoration: none;
         box-shadow: 0 0.25rem 0.5rem 0 rgba(0, 0, 0, 0.05);
         position: relative;
@@ -114,13 +113,9 @@ const categoryData = getCategoryData(post.frontmatter.category);
         color: var(--color-text);
         font-size: 1.25rem;
         font-weight: 600;
-        position: absolute;
-        top: -0.8rem;
-        left: 1rem;
-        background-color: var(--color-background);
-        padding-inline: 0.5rem;
+        margin-block-end: 0.75rem;
         display: -webkit-box;
-        -webkit-line-clamp: 1;
+        -webkit-line-clamp: 2;
         -webkit-box-orient: vertical;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -159,6 +154,21 @@ const categoryData = getCategoryData(post.frontmatter.category);
     }
 
     @media (min-width: 40rem) {
+        .card {
+            padding-block-start: 2rem;
+            margin-block-start: 3rem;
+        }
+
+        & .card-title {
+            position: absolute;
+            top: -0.8rem;
+            left: 1rem;
+            background-color: var(--color-background);
+            padding-inline: 0.5rem;
+            margin-block-end: 0;
+            -webkit-line-clamp: 1;
+        }
+
         & .card-description {
             -webkit-line-clamp: 3;
         }


### PR DESCRIPTION
Previously, the title clamped after 1 line. This is problematic on mobile layouts since there are only a few words visible. Increasing the clamping is gonna be difficult since the positioning needs to be dynamic depending on the number of lines... So simplicity instead just put the title in the PostCard on mobile layouts.